### PR TITLE
Expose reactive streams consume each

### DIFF
--- a/kmongo-coroutine-core/src/main/kotlin/org/litote/kmongo/coroutine/CoroutinePublisher.kt
+++ b/kmongo-coroutine-core/src/main/kotlin/org/litote/kmongo/coroutine/CoroutinePublisher.kt
@@ -44,4 +44,11 @@ open class CoroutinePublisher<T>(private val publisher: Publisher<T>) {
      * Provides a list of not null elements from the publisher.
      */
     suspend fun toList(): List<T> = publisher.toList()
+
+    /**
+     * iterates over all elements from the publisher
+     */
+    suspend fun consumeEach(action: (T) -> kotlin.Unit): kotlin.Unit {
+        publisher.consumeEach(action)
+    }
 }

--- a/kmongo-coroutine-core/src/main/kotlin/org/litote/kmongo/coroutine/CoroutinePublisher.kt
+++ b/kmongo-coroutine-core/src/main/kotlin/org/litote/kmongo/coroutine/CoroutinePublisher.kt
@@ -48,7 +48,7 @@ open class CoroutinePublisher<T>(private val publisher: Publisher<T>) {
     /**
      * iterates over all elements from the publisher
      */
-    suspend fun consumeEach(action: (T) -> kotlin.Unit): kotlin.Unit {
-        publisher.consumeEach(action)
+    suspend fun consumeEach(action: suspend (T) -> kotlin.Unit): kotlin.Unit {
+        publisher.consumeEach { action(it) }
     }
 }


### PR DESCRIPTION
Since publish is a private member of CoroutinePublisher, there is no way to call consumeEach on coroutine-augmented publishers. 

An option is to expose a consumeEach on CouroutinePublisher. This is what this PR does.