### PR TITLE
warning about using object values with contains filter

### DIFF
--- a/kmongo-property/src/main/kotlin/org/litote/kmongo/Filters.kt
+++ b/kmongo-property/src/main/kotlin/org/litote/kmongo/Filters.kt
@@ -42,6 +42,11 @@ infix fun <T> KProperty<T>.eq(value: T): Bson = Filters.eq<T>(path(), value)
  * Creates a filter that matches all documents where the value of the property contains the specified value. Note that this doesn't
  * actually generate a $eq operator, as the query language doesn't require it.
  *
+ * Please be aware that although <TItem> can be an object, using this filter to find objects is extremely fragile.
+ * In particular, MongoDB only consider two documents equal if they have the same set of key/value pairs, in the same order.
+ *
+ * The elemMatch filter is a much better alternative for Object <TItem> values.
+ *
  * @param value     the value
  * @param <TItem>   the value type
  * @return the filter


### PR DESCRIPTION
the contains filter is extremely fragile when trying to find document having documents in an array. 
The equality operator in Mongo is extremely strict on documents : 
- documents must have the same exact values (in particular, null values must be passed in filter, which is not done by default by POJO serializer, at least)
- document key/value pairs must be given in the same exact order as they are stored in persisted document. 

A real fix would be to use $elemMatch when TValue is not a simple type. 

In the meantime, a little bit of documentation doesn't hurt.