### PR TITLE
Fix for using sequences

### DIFF
--- a/kmongo-core/src/main/kotlin/kotlin/collections/KMongoIterable.kt
+++ b/kmongo-core/src/main/kotlin/kotlin/collections/KMongoIterable.kt
@@ -140,8 +140,8 @@ fun <T : Any> MongoIterable<T?>.requireNoNulls(): Iterable<T> =
  *
  * @sample samples.collections.Sequences.Building.sequenceFromCollection
  */
-fun <T> MongoIterable<T>.asSequence(): Sequence<T> {
-    return toList().asSequence()
+fun <T : Any> MongoIterable<T>.asSequence(): Sequence<T> {
+    return iterator().let { generateSequence { it.tryNext() } }
 }
 
 //common overrides ->


### PR DESCRIPTION
The current implementation of `MongoIterable.asSequence()` first converts the MongoIterable to a list and then to a Sequence. This means it puts all values of MongoIterable in memory upon creation.

By manually creating the sequence based on the iterator it becomes a lazily evaluated collection.