### PR TITLE
Support nullable collection properties by "/"

### DIFF
--- a/kmongo-property/src/main/kotlin/org/litote/kmongo/Properties.kt
+++ b/kmongo-property/src/main/kotlin/org/litote/kmongo/Properties.kt
@@ -52,7 +52,7 @@ fun <T> KProperty<T>.path(): String =
 /**
  * Returns a collection property.
  */
-val <T> KProperty1<out Any?, Iterable<T>>.colProperty: KCollectionSimplePropertyPath<out Any?, T>
+val <T> KProperty1<out Any?, Iterable<T>?>.colProperty: KCollectionSimplePropertyPath<out Any?, T>
     get() = KCollectionSimplePropertyPath(null, this)
 
 


### PR DESCRIPTION
Chaining like this:
```kotlin
println("parts.$[part].questionGroups.$[questionGroup].questions")
println(
    ((FormTemplateEntity::parts.colProperty.filteredPosOp("part") / FormTemplatePartEntity::questionGroups)
        .colProperty.filteredPosOp("questionGroup") / FormTemplateQuestionGroupEntity::questions).path()
)
```
doesn't work because nullable collection properties are not supported by the div operator