### PR TITLE
Should check parent classes for Id property

### DIFF
--- a/kmongo-serialization-mapping/src/main/kotlin/IdController.kt
+++ b/kmongo-serialization-mapping/src/main/kotlin/IdController.kt
@@ -23,6 +23,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.javaField
 
@@ -55,7 +56,11 @@ object ReflectionIdController : IdController {
 
     @ImplicitReflectionSerializer
     override fun findIdProperty(type: KClass<*>): KProperty1<*, *>? {
-        return type.declaredMemberProperties.find { it.name == "_id" || it.findAnnotation<SerialName>()?.value == "_id" }
+        var property = type.declaredMemberProperties.find { it.name == "_id" || it.findAnnotation<SerialName>()?.value == "_id" }
+        if (property == null) {
+            property = type.memberProperties.find { it.name == "_id" || it.findAnnotation<SerialName>()?.value == "_id" }
+        }
+        return property
     }
 
     override fun <T, R> getIdValue(idProperty: KProperty1<T, R>, instance: T): R? {


### PR DESCRIPTION
Hi,

The findIdProperty function in ReflectionIdController (kotlinx serialization) currently only checks id property on declaredMemberProperties.
The problem comes when we use inheritance.
For example: I have an abstract class BaseModel with @SerialName(_id) property.
I create a class ChildModel which inherits from BaseModel but I don't redefine the id property.
Currently the id won't be found. With this PR it will check for Id property first on the class and then on the parent classes with memberProperties.
Best,
JB