### PR TITLE
Support elemMatch for nullable iterable

### DIFF
--- a/kmongo-property/src/main/kotlin/org/litote/kmongo/Filters.kt
+++ b/kmongo-property/src/main/kotlin/org/litote/kmongo/Filters.kt
@@ -399,7 +399,7 @@ fun <@OnlyInputTypes T> KProperty<Iterable<T>?>.all(vararg values: T): Bson = Fi
  * @return the filter
  * @mongodb.driver.manual reference/operator/query/elemMatch $elemMatch
  */
-infix fun <T> KProperty<Iterable<T>>.elemMatch(filter: Bson): Bson = Filters.elemMatch(path(), filter)
+infix fun <T> KProperty<Iterable<T>?>.elemMatch(filter: Bson): Bson = Filters.elemMatch(path(), filter)
 
 /**
  * Creates a filter that matches all documents where the value of a property is an array of the specified size.


### PR DESCRIPTION
I required it for this to work: `item::someProperty / SomePropertyType::collection elemMatch document`