### PR TITLE
Fix object in polymorphic serializer throw Exception

### DIFF
--- a/kmongo-kbson/src/main/kotlin/com/github/jershell/kbson/BsonEncoder.kt
+++ b/kmongo-kbson/src/main/kotlin/com/github/jershell/kbson/BsonEncoder.kt
@@ -81,7 +81,7 @@ open class BsonEncoder(
     override fun endStructure(desc: SerialDescriptor) {
         when (desc.kind) {
             is StructureKind.LIST -> writer.writeEndArray()
-            is StructureKind.MAP, StructureKind.CLASS -> writer.writeEndDocument()
+            is StructureKind.MAP, StructureKind.CLASS, UnionKind.OBJECT -> writer.writeEndDocument()
         }
     }
 

--- a/kmongo-kbson/src/main/kotlin/com/github/jershell/kbson/BsonEncoder.kt
+++ b/kmongo-kbson/src/main/kotlin/com/github/jershell/kbson/BsonEncoder.kt
@@ -57,7 +57,14 @@ open class BsonEncoder(
                     writer.writeStartDocument()
                 }
             }
-            UnionKind.OBJECT, is PolymorphicKind -> {
+            UnionKind.OBJECT-> {
+                if(hasBegin){
+                    hasBegin = false
+                } else{
+                    writer.writeStartDocument()
+                }
+            }
+            is PolymorphicKind -> {
                 writer.writeStartDocument()
                 writer.writeName(configuration.classDiscriminator)
                 hasBegin = true

--- a/kmongo-kbson/src/main/kotlin/com/github/jershell/kbson/BsonFlexibleDecoder.kt
+++ b/kmongo-kbson/src/main/kotlin/com/github/jershell/kbson/BsonFlexibleDecoder.kt
@@ -16,18 +16,9 @@
 
 package com.github.jershell.kbson
 
-import kotlinx.serialization.CompositeDecoder
+import kotlinx.serialization.*
 import kotlinx.serialization.CompositeDecoder.Companion.READ_DONE
 import kotlinx.serialization.CompositeDecoder.Companion.UNKNOWN_NAME
-import kotlinx.serialization.DeserializationStrategy
-import kotlinx.serialization.ElementValueDecoder
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.PolymorphicKind
-import kotlinx.serialization.PolymorphicSerializer
-import kotlinx.serialization.SerialDescriptor
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.StructureKind
-import kotlinx.serialization.decode
 import kotlinx.serialization.modules.SerialModule
 import org.bson.AbstractBsonReader
 import org.bson.AbstractBsonReader.State
@@ -67,7 +58,7 @@ abstract class FlexibleDecoder(
     override fun endStructure(desc: SerialDescriptor) {
         when (desc.kind) {
             is StructureKind.LIST -> reader.readEndArray()
-            is StructureKind.MAP, StructureKind.CLASS -> reader.readEndDocument()
+            is StructureKind.MAP, StructureKind.CLASS, UnionKind.OBJECT -> reader.readEndDocument()
         }
     }
 

--- a/kmongo-serialization/src/test/kotlin/ObjectInPolymorphicNotWorking.kt
+++ b/kmongo-serialization/src/test/kotlin/ObjectInPolymorphicNotWorking.kt
@@ -1,0 +1,58 @@
+import com.github.jershell.kbson.BsonEncoder
+import com.github.jershell.kbson.BsonFlexibleDecoder
+import com.github.jershell.kbson.Configuration
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.EmptyModule
+import org.bson.BsonDocument
+import org.bson.BsonDocumentReader
+import org.bson.BsonDocumentWriter
+import org.junit.Test
+import kotlin.test.assertEquals
+
+@Serializable
+sealed class Message
+
+@Serializable
+data class StringMessage(val message: String) : Message()
+
+@Serializable
+data class IntMessage(val int: Int) : Message()
+
+@Serializable
+object ObjectMessage : Message() {
+    val message: String = "Message"
+}
+
+class ObjectInPolymorphicNotWorking {
+    @Test
+    fun `serialize and deserialize object in polymorphic`() {
+        val document = BsonDocument()
+        val writer = BsonDocumentWriter(document)
+        val encoder = BsonEncoder(writer, EmptyModule, Configuration())
+        Message.serializer().serialize(encoder, ObjectMessage)
+        val expected = BsonDocument.parse("""{"___type":"ObjectMessage"}""")
+        assertEquals(expected, document)
+
+        val reader = BsonDocumentReader(document)
+        val decoder = BsonFlexibleDecoder(reader, EmptyModule, Configuration())
+        val parsed = Message.serializer().deserialize(decoder)
+        assertEquals(ObjectMessage, parsed)
+    }
+
+    @Test
+    fun `serialize and deserialize class in polymorphic`(){
+        val message = StringMessage("msg")
+
+        val document = BsonDocument()
+        val writer = BsonDocumentWriter(document)
+        val encoder = BsonEncoder(writer, EmptyModule, Configuration())
+        Message.serializer().serialize(encoder, message)
+        val expected = BsonDocument.parse("""{"___type":"StringMessage", "message":"msg"}""")
+        assertEquals(expected, document)
+
+        val reader = BsonDocumentReader(document)
+        val decoder = BsonFlexibleDecoder(reader, EmptyModule, Configuration())
+        val parsed = Message.serializer().deserialize(decoder)
+        assertEquals(message, parsed)
+    }
+}


### PR DESCRIPTION
When using kotlinx.serialization, object in polymorphic serializer throw org.bson.BsonInvalidOperationException.
Following  is simple example and stack trace.

```kotlin
@Serializable
sealed class SuperClass{
    @Serializable
    object SubClassA: SuperClass()
    @Serializable
    data class SubClassB(val b: String): SuperClass()
    @Serializable
    data class SubClassC(val c: Long): SuperClass()
}

fun main(){
    val document = BsonDocument()
    val writer = BsonDocumentWriter(document)
    val encoder = BsonEncoder(writer, EmptyModule, Configuration())
    SuperClass.serializer()
        .serialize(encoder, SuperClass.SubClassA)
    writer.flush()
    println(document.toJson())
}
```

```
Exception in thread "main" org.bson.BsonInvalidOperationException: writeStartDocument can only be called when State is INITIAL or VALUE or SCOPE_DOCUMENT or DONE, not when State is NAME
	at org.bson.AbstractBsonWriter.throwInvalidState(AbstractBsonWriter.java:744)
	at org.bson.AbstractBsonWriter.checkPreconditions(AbstractBsonWriter.java:699)
	at org.bson.AbstractBsonWriter.writeStartDocument(AbstractBsonWriter.java:277)
	at com.github.jershell.kbson.BsonEncoder.beginStructure(BsonEncoder.kt:45)
	at kotlinx.serialization.internal.ObjectSerializer.serialize(ObjectSerializer.kt:20)
	at kotlinx.serialization.Encoder$DefaultImpls.encodeSerializableValue(Coders.kt:29)
	at kotlinx.serialization.ElementValueEncoder.encodeSerializableValue(ElementWise.kt:12)
	at kotlinx.serialization.ElementValueEncoder.encodeSerializableElement(ElementWise.kt:72)
	at kotlinx.serialization.internal.AbstractPolymorphicSerializer.serialize(AbstractPolymorphicSerializer.kt:34)
	at TestKt.main(Test.kt:33)
	at TestKt.main(Test.kt)
```

Current BsonEncoder always call `writer.writeStartDocument()` for `UnionKind.OBJECT` since `StructureKind.CLASS` call it only if `hasBegin` is `false`. Therefore, I edit `UnionKind.OBJECT` to use same logic as `StructureKind.CLASS`. `ObjectInPolymorphicNotWorking` shows it works well with Object and does not broke Class serialization. 
