### PR TITLE
Migrate to kotlin 1.3.70 and kotlinx-serialization 0.20.0

### DIFF
--- a/kmongo-kbson/src/main/kotlin/com/github/jershell/kbson/Serializers.kt
+++ b/kmongo-kbson/src/main/kotlin/com/github/jershell/kbson/Serializers.kt
@@ -16,16 +16,8 @@
 
 package com.github.jershell.kbson
 
-import kotlinx.serialization.Decoder
-import kotlinx.serialization.Encoder
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerialDescriptor
-import kotlinx.serialization.SerialInfo
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.Serializer
-import kotlinx.serialization.internal.StringDescriptor
+import kotlinx.serialization.*
 import kotlinx.serialization.modules.serializersModuleOf
-import kotlinx.serialization.withName
 import org.bson.BsonType
 import org.bson.types.Decimal128
 import org.bson.types.ObjectId
@@ -39,11 +31,11 @@ annotation class NonEncodeNull
 
 @Serializer(forClass = Date::class)
 object DateSerializer : KSerializer<Date> {
-    override val descriptor: SerialDescriptor = StringDescriptor.withName("DateSerializer")
+    override val descriptor: SerialDescriptor = PrimitiveDescriptor("DateSerializer", PrimitiveKind.STRING)
 
-    override fun serialize(encoder: Encoder, obj: Date) {
+    override fun serialize(encoder: Encoder, value: Date) {
         encoder as BsonEncoder
-        encoder.encodeDateTime(obj.time)
+        encoder.encodeDateTime(value.time)
     }
 
     override fun deserialize(decoder: Decoder): Date {
@@ -66,11 +58,11 @@ object DateSerializer : KSerializer<Date> {
 @Serializer(forClass = BigDecimal::class)
 object BigDecimalSerializer : KSerializer<BigDecimal> {
     override val descriptor: SerialDescriptor =
-        StringDescriptor.withName("BigDecimalSerializer")
+        PrimitiveDescriptor("BigDecimalSerializer", PrimitiveKind.STRING)
 
-    override fun serialize(encoder: Encoder, obj: BigDecimal) {
+    override fun serialize(encoder: Encoder, value: BigDecimal) {
         encoder as BsonEncoder
-        encoder.encodeDecimal128(Decimal128(obj))
+        encoder.encodeDecimal128(Decimal128(value))
     }
 
     override fun deserialize(decoder: Decoder): BigDecimal {
@@ -91,11 +83,11 @@ object BigDecimalSerializer : KSerializer<BigDecimal> {
 @Serializer(forClass = ByteArray::class)
 object ByteArraySerializer : KSerializer<ByteArray> {
     override val descriptor: SerialDescriptor =
-        StringDescriptor.withName("ByteArraySerializer")
+        PrimitiveDescriptor("ByteArraySerializer", PrimitiveKind.STRING)
 
-    override fun serialize(encoder: Encoder, obj: ByteArray) {
+    override fun serialize(encoder: Encoder, value: ByteArray) {
         encoder as BsonEncoder
-        encoder.encodeByteArray(obj)
+        encoder.encodeByteArray(value)
     }
 
     override fun deserialize(decoder: Decoder): ByteArray {
@@ -112,11 +104,11 @@ object ByteArraySerializer : KSerializer<ByteArray> {
 
 @Serializer(forClass = ObjectId::class)
 object ObjectIdSerializer : KSerializer<ObjectId> {
-    override val descriptor: SerialDescriptor = StringDescriptor.withName("ObjectIdSerializer")
+    override val descriptor: SerialDescriptor = PrimitiveDescriptor("ObjectIdSerializer", PrimitiveKind.STRING)
 
-    override fun serialize(encoder: Encoder, obj: ObjectId) {
+    override fun serialize(encoder: Encoder, value: ObjectId) {
         encoder as BsonEncoder
-        encoder.encodeObjectId(obj)
+        encoder.encodeObjectId(value)
     }
 
     override fun deserialize(decoder: Decoder): ObjectId {

--- a/kmongo-serialization-mapping/src/main/kotlin/KMongoSerializationRepository.kt
+++ b/kmongo-serialization-mapping/src/main/kotlin/KMongoSerializationRepository.kt
@@ -25,10 +25,10 @@ import kotlinx.serialization.ImplicitReflectionSerializer
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.PolymorphicSerializer
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.internal.PairSerializer
-import kotlinx.serialization.internal.ReferenceArraySerializer
-import kotlinx.serialization.internal.StringSerializer
-import kotlinx.serialization.internal.TripleSerializer
+import kotlinx.serialization.builtins.ArraySerializer
+import kotlinx.serialization.builtins.PairSerializer
+import kotlinx.serialization.builtins.TripleSerializer
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonNullSerializer
 import kotlinx.serialization.modules.SerialModule
 import kotlinx.serialization.modules.SerializersModule
@@ -129,10 +129,10 @@ internal object KMongoSerializationRepository {
                 getSerializer(obj.second),
                 getSerializer(obj.third)
             )
-            is Array<*> -> ReferenceArraySerializer(
+            is Array<*> -> ArraySerializer(
                 kClass as KClass<Any>,
                 obj.filterNotNull().let {
-                    if (it.isEmpty()) StringSerializer else getSerializer(it.first())
+                    if (it.isEmpty()) String.serializer() else getSerializer(it.first())
                 } as KSerializer<Any>
             )
             else -> module.getContextual(kClass)

--- a/kmongo-serialization-mapping/src/main/kotlin/Serializers.kt
+++ b/kmongo-serialization-mapping/src/main/kotlin/Serializers.kt
@@ -19,13 +19,8 @@ package org.litote.kmongo.serialization
 import com.github.jershell.kbson.BsonEncoder
 import com.github.jershell.kbson.FlexibleDecoder
 import com.github.jershell.kbson.ObjectIdSerializer
-import kotlinx.serialization.Decoder
-import kotlinx.serialization.Encoder
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerialDescriptor
-import kotlinx.serialization.SerializationException
+import kotlinx.serialization.*
 import kotlinx.serialization.internal.StringDescriptor
-import kotlinx.serialization.withName
 import org.bson.AbstractBsonReader.State
 import org.bson.BsonTimestamp
 import org.bson.BsonType
@@ -55,7 +50,7 @@ import kotlin.reflect.KProperty
  */
 abstract class TemporalExtendedJsonSerializer<T> : KSerializer<T> {
 
-    override val descriptor: SerialDescriptor = StringDescriptor.withName(javaClass.simpleName)
+    override val descriptor: SerialDescriptor = PrimitiveDescriptor(javaClass.simpleName, PrimitiveKind.STRING)
 
     /**
      * Returns the number of milliseconds since January 1, 1970, 00:00:00 GMT
@@ -180,7 +175,7 @@ object BsonTimestampSerializer : TemporalExtendedJsonSerializer<BsonTimestamp>()
 //@Serializer(forClass = Binary::class)
 object BinarySerializer : KSerializer<Binary> {
 
-    override val descriptor: SerialDescriptor = StringDescriptor.withName("BinarySerializer")
+    override val descriptor: SerialDescriptor = PrimitiveDescriptor("BinarySerializer", PrimitiveKind.STRING)
     override fun deserialize(decoder: Decoder): Binary =
         Binary((decoder as FlexibleDecoder).reader.readBinaryData().data)
 
@@ -192,7 +187,7 @@ object BinarySerializer : KSerializer<Binary> {
 //@Serializer(forClass = Locale::class)
 object LocaleSerializer : KSerializer<Locale> {
 
-    override val descriptor: SerialDescriptor = StringDescriptor.withName("LocaleSerializer")
+    override val descriptor: SerialDescriptor = PrimitiveDescriptor("LocaleSerializer", PrimitiveKind.STRING)
     override fun deserialize(decoder: Decoder): Locale = Locale.forLanguageTag(decoder.decodeString())
 
     override fun serialize(encoder: Encoder, obj: Locale) {
@@ -203,7 +198,7 @@ object LocaleSerializer : KSerializer<Locale> {
 //@Serializer(forClass = KProperty::class)
 object KPropertySerializer : KSerializer<KProperty<*>> {
 
-    override val descriptor: SerialDescriptor = StringDescriptor.withName("KPropertySerializer")
+    override val descriptor: SerialDescriptor = PrimitiveDescriptor("KPropertySerializer", PrimitiveKind.STRING)
     override fun deserialize(decoder: Decoder): KProperty<*> = error("KProperty deserialization is unsupported")
 
     override fun serialize(encoder: Encoder, obj: KProperty<*>) {
@@ -214,7 +209,7 @@ object KPropertySerializer : KSerializer<KProperty<*>> {
 //@Serializer(forClass = Id::class)
 internal class IdSerializer<T : Id<*>>(val shouldBeStringId: Boolean) : KSerializer<T> {
 
-    override val descriptor: SerialDescriptor = StringDescriptor.withName("IdSerializer")
+    override val descriptor: SerialDescriptor = PrimitiveDescriptor("IdSerializer", PrimitiveKind.STRING)
 
     @Suppress("UNCHECKED_CAST")
     override fun deserialize(decoder: Decoder): T =

--- a/kmongo-serialization-mapping/src/test/kotlin/SerializationCodecTest.kt
+++ b/kmongo-serialization-mapping/src/test/kotlin/SerializationCodecTest.kt
@@ -16,17 +16,8 @@
 
 package org.litote.kmongo.serialization
 
-import kotlinx.serialization.CompositeDecoder
-import kotlinx.serialization.CompositeEncoder
-import kotlinx.serialization.ContextualSerialization
-import kotlinx.serialization.Decoder
-import kotlinx.serialization.Encoder
-import kotlinx.serialization.ImplicitReflectionSerializer
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.Serializer
-import kotlinx.serialization.internal.SerialClassDescImpl
-import kotlinx.serialization.internal.StringDescriptor
+import kotlinx.serialization.*
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.modules.SerializersModule
 import org.bson.BsonDocument
 import org.bson.BsonDocumentReader
@@ -121,27 +112,23 @@ class SerializationCodecTest {
 
     @Serializer(forClass = Custom::class)
     object CustomSerializer : KSerializer<Custom> {
-
-        object CustomClassDesc : SerialClassDescImpl("Custom") {
-            init {
-                addElement("s")
-                pushDescriptor(StringDescriptor)
-            }
+        override val descriptor: SerialDescriptor = SerialDescriptor("Custom"){
+            element("s", String.serializer().descriptor)
         }
 
         override fun deserialize(decoder: Decoder): Custom {
             decoder as CompositeDecoder
-            decoder.beginStructure(CustomClassDesc)
-            val c = Custom(decoder.decodeStringElement(CustomClassDesc, 0))
-            decoder.endStructure(CustomClassDesc)
+            decoder.beginStructure(descriptor)
+            val c = Custom(decoder.decodeStringElement(descriptor, 0))
+            decoder.endStructure(descriptor)
             return c
         }
 
         override fun serialize(encoder: Encoder, obj: Custom) {
             encoder as CompositeEncoder
-            encoder.beginStructure(CustomClassDesc)
-            encoder.encodeStringElement(CustomClassDesc, 0, obj.s)
-            encoder.endStructure(CustomClassDesc)
+            encoder.beginStructure(descriptor)
+            encoder.encodeStringElement(descriptor, 0, obj.s)
+            encoder.endStructure(descriptor)
         }
     }
 
@@ -238,7 +225,7 @@ class SerializationCodecTest {
             codec.encode(writer, c, EncoderContext.builder().build())
         }
         assertEquals(
-            "Can't locate argument-less serializer for class org.litote.kmongo.serialization.SerializationCodecTest\$NotSerializableClass. For generic classes, such as lists, please provide serializer explicitly.",
+            "Can't locate argument-less serializer for class NotSerializableClass. For generic classes, such as lists, please provide serializer explicitly.",
             t.message
         )
     }
@@ -257,7 +244,7 @@ class SerializationCodecTest {
             codec2.decode(BsonDocumentReader(document), DecoderContext.builder().build())
         }
         assertEquals(
-            "Can't locate argument-less serializer for class org.litote.kmongo.serialization.SerializationCodecTest\$NotSerializableClass. For generic classes, such as lists, please provide serializer explicitly.",
+            "Can't locate argument-less serializer for class NotSerializableClass. For generic classes, such as lists, please provide serializer explicitly.",
             t.message
         )
     }

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 
     <properties>
         <!-- dependencies -->
-        <kotlin.version>1.3.61</kotlin.version>
+        <kotlin.version>1.3.70</kotlin.version>
         <mongo.version>3.12.1</mongo.version>
         <mongo.base.version>3.10</mongo.base.version>
         <coroutine.version>1.3.3</coroutine.version>
@@ -80,7 +80,7 @@
         <kreflect.version>1.0.0</kreflect.version>
         <jackson-module-loader.version>0.1.0</jackson-module-loader.version>
         <reactivestreams.version>1.13.0</reactivestreams.version>
-        <kotlinx-serialization.version>0.14.0</kotlinx-serialization.version>
+        <kotlinx-serialization.version>0.20.0</kotlinx-serialization.version>
 
         <!-- annotations processor -->
         <kgenerator.version>0.3.0</kgenerator.version>


### PR DESCRIPTION
- Match parameter name to it's implementing method
- Fix PolymorphismDecoder always return 0 as element index.
- Fix assertion since kotlinx-serialization change exception message
- Fix deprecated method and class usage.
