### PR TITLE
support 'id' property in model objects 

### DIFF
--- a/kmongo-jackson-mapping/src/main/kotlin/org/litote/kmongo/util/MongoIdUtil.kt
+++ b/kmongo-jackson-mapping/src/main/kotlin/org/litote/kmongo/util/MongoIdUtil.kt
@@ -79,7 +79,7 @@ internal object MongoIdUtil {
 
     private fun getIdProperty(type: KClass<*>): KProperty1<*, *>? =
         try {
-            type.memberProperties.find { "_id" == it.name }
+            type.memberProperties.find { "_id" == it.name || "id" == it.name }
         } catch (error: KotlinReflectionInternalError) {
             //ignore
             null

--- a/kmongo-jackson-mapping/src/test/kotlin/org/litote/kmongo/jackson/UUIDTest.kt
+++ b/kmongo-jackson-mapping/src/test/kotlin/org/litote/kmongo/jackson/UUIDTest.kt
@@ -63,7 +63,7 @@ class UUIDTest
         val bytes = mapper.writeValueAsBytes(testObject)
 
         // Check the type of the binary representation of the UUID
-        assertEquals(if(uuidRepresentation == UuidRepresentation.STANDARD) 4 else 3, bytes[12].toInt())
+        assertEquals(if(uuidRepresentation == UuidRepresentation.STANDARD) 4 else 3, bytes[13].toInt())
 
         val decodedObject: TestingObject = mapper.readValue(bytes)
 

--- a/kmongo-jackson-mapping/src/test/kotlin/org/litote/kmongo/jackson/UUIDTest.kt
+++ b/kmongo-jackson-mapping/src/test/kotlin/org/litote/kmongo/jackson/UUIDTest.kt
@@ -63,7 +63,7 @@ class UUIDTest
         val bytes = mapper.writeValueAsBytes(testObject)
 
         // Check the type of the binary representation of the UUID
-        assertEquals(if(uuidRepresentation == UuidRepresentation.STANDARD) 4 else 3, bytes[13].toInt())
+        assertEquals(if(uuidRepresentation == UuidRepresentation.STANDARD) 4 else 3, bytes[12].toInt())
 
         val decodedObject: TestingObject = mapper.readValue(bytes)
 

--- a/kmongo-jackson-mapping/src/test/kotlin/org/litote/kmongo/util/MongoIdUtilTest.kt
+++ b/kmongo-jackson-mapping/src/test/kotlin/org/litote/kmongo/util/MongoIdUtilTest.kt
@@ -72,5 +72,11 @@ class MongoIdUtilTest : KMongoRootTest() {
         assertEquals(Foo::class.memberProperties.first { it.name == "id" }, Foo::class.idProperty)
     }
 
+    data class TestObjWithId(val id : String?)
+
+    @Test
+    fun extractIdWithoutUnderscore() {
+        assertEquals("id", KMongoUtil.extractId(TestObjWithId("id"), TestObjWithId::class))
+    }
 
 }

--- a/kmongo-jackson-mapping/src/test/kotlin/org/litote/kmongo/util/MongoIdUtilTest.kt
+++ b/kmongo-jackson-mapping/src/test/kotlin/org/litote/kmongo/util/MongoIdUtilTest.kt
@@ -68,6 +68,13 @@ class MongoIdUtilTest : KMongoRootTest() {
     }
 
     @Test
+    fun extractIdIfIdNotEnabled() {
+        System.setProperty("kmongo.id.enabled", "false")
+        val id = ObjectId()
+        assertEquals(id, KMongoUtil.extractId(Obj(id), Obj::class))
+    }
+
+    @Test
     fun `id property is detected even for java classes`() {
         assertEquals(Foo::class.memberProperties.first { it.name == "id" }, Foo::class.idProperty)
     }
@@ -76,7 +83,10 @@ class MongoIdUtilTest : KMongoRootTest() {
 
     @Test
     fun extractIdWithoutUnderscore() {
+        System.setProperty("kmongo.id.enabled", "true")
         assertEquals("id", KMongoUtil.extractId(TestObjWithId("id"), TestObjWithId::class))
+        System.setProperty("kmongo.id.enabled", "false")
     }
+
 
 }


### PR DESCRIPTION
The current version supports '_id' property only, with this change it can handle 'id' as well