### PR TITLE
Fix CoroutineCollection.createIndexes

### DIFF
--- a/kmongo-coroutine-core/src/main/kotlin/org/litote/kmongo/coroutine/CoroutineCollection.kt
+++ b/kmongo-coroutine-core/src/main/kotlin/org/litote/kmongo/coroutine/CoroutineCollection.kt
@@ -811,7 +811,7 @@ class CoroutineCollection<T : Any>(val collection: MongoCollection<T>) {
      *
      * @param indexes the list of indexes
      * @param createIndexOptions options to use when creating indexes
-     * @return a single element indicating when the operation has completed
+     * @return a list of elements indicating index creation operation completion
      * @mongodb.driver.manual reference/command/createIndexes Create indexes
      * @mongodb.server.release 2.6
      * @since 1.7
@@ -819,8 +819,8 @@ class CoroutineCollection<T : Any>(val collection: MongoCollection<T>) {
     suspend fun createIndexes(
         indexes: List<IndexModel>,
         createIndexOptions: CreateIndexOptions = CreateIndexOptions()
-    ): String =
-        collection.createIndexes(indexes, createIndexOptions).awaitSingle()
+    ): List<String> =
+        collection.createIndexes(indexes, createIndexOptions).toList()
 
     /**
      * Create multiple indexes.
@@ -828,7 +828,7 @@ class CoroutineCollection<T : Any>(val collection: MongoCollection<T>) {
      * @param clientSession the client session with which to associate this operation
      * @param indexes the list of indexes
      * @param createIndexOptions options to use when creating indexes
-     * @return a publisher with a single element indicating when the operation has completed
+     * @return a list of elements indicating index creation operation completion
      * @mongodb.driver.manual reference/command/createIndexes Create indexes
      * @mongodb.server.release 3.6
      * @since 1.7
@@ -837,8 +837,8 @@ class CoroutineCollection<T : Any>(val collection: MongoCollection<T>) {
         clientSession: ClientSession,
         indexes: List<IndexModel>,
         createIndexOptions: CreateIndexOptions = CreateIndexOptions()
-    ): String =
-        collection.createIndexes(clientSession, indexes, createIndexOptions).awaitSingle()
+    ): List<String> =
+        collection.createIndexes(clientSession, indexes, createIndexOptions).toList()
 
     /**
      * Get all the indexes in this collection.


### PR DESCRIPTION
With the current implementation calling `CoroutineCollection.createIndexes` throws:

```
Caused by: java.lang.IllegalArgumentException: More than one onNext value for awaitSingle
	(Coroutine boundary)
	at org.litote.kmongo.coroutine.CoroutineCollection.createIndexes(CoroutineCollection.kt:823)
	at com.skkap.lookback.server.job.EnsureMongodbIndexesJob$ensureIndexes$2.invokeSuspend(EnsureMongodbIndexesJob.kt:18)
Caused by: java.lang.IllegalArgumentException: More than one onNext value for awaitSingle
	at kotlinx.coroutines.reactive.AwaitKt$awaitOne$2$1.onNext(Await.kt:240)
	at reactor.core.publisher.StrictSubscriber.onNext(StrictSubscriber.java:89)
	at reactor.core.publisher.FluxConcatArray$ConcatArraySubscriber.onNext(FluxConcatArray.java:201)
	at reactor.core.publisher.FluxIterable$IterableSubscription.fastPath(FluxIterable.java:340)
	at reactor.core.publisher.FluxIterable$IterableSubscription.request(FluxIterable.java:227)
...
```

I am not confident about the fix, but I believe `createIndexes()` returns more than one element from a publisher.

Please let me know if you have some suggestions.