### PR TITLE
Adding ability to use setTo in updateOneById

### DIFF
--- a/kmongo-core-tests/src/main/kotlin/org/litote/kmongo/UpdateTest.kt
+++ b/kmongo-core-tests/src/main/kotlin/org/litote/kmongo/UpdateTest.kt
@@ -70,6 +70,16 @@ class UpdateTest : AllCategoriesKMongoBaseTest<Friend>() {
     }
 
     @Test
+    fun canUpdateWithSetToByObjectId() {
+        val friend = Friend("Paul")
+        col.insertOne(friend)
+        col.updateOneById(friend._id!!, Friend::name setTo "John")
+        val r = col.findOne("{name:'John'}")
+        assertEquals("John", r!!.name)
+        assertEquals(friend._id, r._id)
+    }
+
+    @Test
     fun canUpsert() {
         col.updateOne("{}", "{$set:{name:'John'}}", UpdateOptions().upsert(true))
         val r = col.findOne("{name:'John'}")

--- a/kmongo-core/src/main/kotlin/org/litote/kmongo/MongoCollections.kt
+++ b/kmongo-core/src/main/kotlin/org/litote/kmongo/MongoCollections.kt
@@ -528,6 +528,25 @@ fun <T> MongoCollection<T>.updateOneById(
     updateOne(KMongoUtil.idFilterQuery(id), KMongoUtil.toBsonModifier(update, updateOnlyNotNullProperties), options)
 
 /**
+ * Update a single document in the collection according to the specified arguments.
+ *
+ * @param id        the object id
+ * @param updates   the setTo describing the updates
+ * @param options  the options to apply to the update operation
+ *
+ * @return the result of the update one operation
+ *
+ * @throws com.mongodb.MongoWriteException        if the write failed due some other failure specific to the update command
+ * @throws com.mongodb.MongoWriteConcernException if the write failed due being unable to fulfil the write concern
+ * @throws com.mongodb.MongoException             if the write failed due some other failure
+ */
+fun <T : Any> MongoCollection<T>.updateOneById(
+    id: Any,
+    vararg updates: SetTo<*>,
+    options: UpdateOptions = UpdateOptions()
+): UpdateResult = updateOne(KMongoUtil.idFilterQuery(id), set(*updates), options)
+
+/**
  * Update all documents in the collection according to the specified arguments.
  *
  * @param filter        a document describing the query filter, which may not be null.


### PR DESCRIPTION
Currently, using `setTo` in `updateOneById`  does not throw an error at compile time but raises a SerializationError when used at runtime.

`col.updateOneById(friend._id!!, Friend::name setTo "John")`

This PR fixes this error and provides a test for this issue.