### PR TITLE
#369 Add client metadata for KMongo

### DIFF
--- a/kmongo-async-shared/src/main/kotlin/org/litote/kmongo/reactivestreams/KMongo.kt
+++ b/kmongo-async-shared/src/main/kotlin/org/litote/kmongo/reactivestreams/KMongo.kt
@@ -17,6 +17,7 @@ package org.litote.kmongo.reactivestreams
 
 import com.mongodb.ConnectionString
 import com.mongodb.MongoClientSettings
+import com.mongodb.MongoDriverInformation
 import com.mongodb.reactivestreams.client.MongoClient
 import com.mongodb.reactivestreams.client.MongoClients
 import org.bson.codecs.configuration.CodecRegistry
@@ -44,7 +45,8 @@ object KMongo {
         val codecRegistry = ClassMappingType.codecRegistry(settings.codecRegistry)
         return MongoClients.create(
             MongoClientSettings.builder(settings)
-                .codecRegistry(codecRegistry).build()
+                .codecRegistry(codecRegistry).build(),
+            MongoDriverInformation.builder().driverName("kmongo").driverPlatform(String.format("Kotlin/%s", KotlinVersion.CURRENT)).build()
         )
     }
 

--- a/kmongo-core/src/main/kotlin/org/litote/kmongo/KMongo.kt
+++ b/kmongo-core/src/main/kotlin/org/litote/kmongo/KMongo.kt
@@ -20,6 +20,7 @@ package org.litote.kmongo
 import com.mongodb.ConnectionString
 import com.mongodb.MongoClientSettings
 import com.mongodb.MongoClientSettings.getDefaultCodecRegistry
+import com.mongodb.MongoDriverInformation
 import com.mongodb.client.MongoClient
 import com.mongodb.client.MongoClients
 import org.bson.UuidRepresentation
@@ -79,7 +80,8 @@ object KMongo {
                     settings.codecRegistry, settings.uuidRepresentation
                 )
             )
-        ).build()
+        ).build(),
+        MongoDriverInformation.builder().driverName("kmongo").driverPlatform(String.format("Kotlin/%s", KotlinVersion.CURRENT)).build()
     )
 
     private fun createRegistry(codecRegistry: CodecRegistry, uuidRepresentation: UuidRepresentation): CodecRegistry =


### PR DESCRIPTION
Couple of notes about this change:

1. There is some code duplication.  Happy to move it to a common place if anyone has a suggestion as to where it should go
2. It doesn't report a separate version for the KMongo driver.  I think this is ok because KMongo tracks closely with the underlying Java driver, e.g. KMongo 4.7.1 depends on mongodb-driver-sync 4.7.1.  