### PR TITLE
CVE-2022-42003: Bump jackson-databind version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,8 @@
         <rxkotlin.version>2.4.0</rxkotlin.version>
         <reactor.version>2020.0.22</reactor.version>
         <mongo.reactor.adapter.version>0.3.2</mongo.reactor.adapter.version>
-        <jackson.version>2.13.4</jackson.version>
-        <jackson-module.version>2.13.4</jackson-module.version>
+        <jackson.version>2.14.0-rc1</jackson.version>
+        <jackson-module.version>2.14.0-rc1</jackson-module.version>
         <bson4jackson.version>2.13.1</bson4jackson.version>
         <kreflect.version>1.0.0</kreflect.version>
         <jackson-module-loader.version>0.4.0</jackson-module-loader.version>


### PR DESCRIPTION
This commit bumps `jackson-databind `and `jackson-module-kotlin` to version `2.14.0-rc1` due to CVE-2022-42003 triggering alerts in CI:

https://nvd.nist.gov/vuln/detail/CVE-2022-42003

