### PR TITLE
Added possibility to customize `ObjectMapper`'s `KotlinModule`

### DIFF
--- a/kmongo-jackson-mapping/src/main/kotlin/org/litote/kmongo/jackson/ObjectMapperFactory.kt
+++ b/kmongo-jackson-mapping/src/main/kotlin/org/litote/kmongo/jackson/ObjectMapperFactory.kt
@@ -28,13 +28,15 @@ import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.mongodb.BasicDBObject
 import com.mongodb.DBObject
 import com.mongodb.DBRef
 import org.bson.UuidRepresentation
 import org.bson.types.ObjectId
 import org.litote.jackson.registerModulesFromServiceLoader
+import org.litote.kmongo.util.KotlinModuleConfiguration
 import org.litote.kmongo.util.ObjectMappingConfiguration
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -49,7 +51,7 @@ internal object ObjectMapperFactory {
 
     fun createExtendedJsonObjectMapper(): ObjectMapper {
         return ObjectMapper()
-            .registerKotlinModule()
+            .registerModule(kotlinModule(KotlinModuleConfiguration.kotlinModuleInitializer))
             .registerModule(SetMappingModule())
             .registerModule(ExtendedJsonModule())
             .configure(MapperFeature.PROPAGATE_TRANSIENT_MARKER, true)
@@ -67,7 +69,7 @@ internal object ObjectMapperFactory {
 
     private fun configureBson(mapper: ObjectMapper, uuidRepresentation: UuidRepresentation?): ObjectMapper {
         return mapper.registerModule(de.undercouch.bson4jackson.BsonModule())
-            .registerKotlinModule()
+            .registerModule(kotlinModule(KotlinModuleConfiguration.kotlinModuleInitializer))
             .registerModule(CustomJacksonModule)
             .registerModule(SetMappingModule())
             .registerModule(BsonModule(uuidRepresentation))
@@ -81,7 +83,6 @@ internal object ObjectMapperFactory {
     fun createFilterIdObjectMapper(objectMapper: ObjectMapper): ObjectMapper {
         return objectMapper.copy().registerModule(FilterIdModule())
     }
-
 }
 
 private object CustomJacksonModule : SimpleModule() {

--- a/kmongo-jackson-mapping/src/main/kotlin/org/litote/kmongo/util/KMongoConfiguration.kt
+++ b/kmongo-jackson-mapping/src/main/kotlin/org/litote/kmongo/util/KMongoConfiguration.kt
@@ -20,10 +20,11 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include.ALWAYS
 import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL
 import com.fasterxml.jackson.databind.Module
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
 import org.bson.UuidRepresentation
 import org.litote.kmongo.jackson.JacksonCodecProvider
 import org.litote.kmongo.jackson.ObjectMapperFactory
-import kotlin.LazyThreadSafetyMode.PUBLICATION
+import org.litote.kmongo.util.KotlinModuleConfiguration.kotlinModuleInitializer
 
 /**
  * Configure the jackson mapper engine.
@@ -39,6 +40,19 @@ object KMongoJacksonFeature {
         KMongoConfiguration.bsonMapper = ObjectMapperFactory.createBsonObjectMapper(uuidRepresentation)
         KMongoConfiguration.bsonMapperCopy = ObjectMapperFactory.createBsonObjectMapperCopy(uuidRepresentation)
     }
+}
+
+/**
+ * Configure the [KotlinModule] used by jackson mapper engine.
+ *
+ * Call the methods of this object *before* any call to [KMongoConfiguration] methods.
+ */
+object KotlinModuleConfiguration {
+
+    /**
+     * Function to customize [KotlinModule] used by KMongo.
+     */
+    var kotlinModuleInitializer: KotlinModule.Builder.() -> Unit = { }
 }
 
 /**

--- a/kmongo-kdoc/docs/object-mapping.md
+++ b/kmongo-kdoc/docs/object-mapping.md
@@ -5,6 +5,22 @@ Query results are automatically mapped to objects.
 Look at the [Quick Start related paragraph](https://litote.org/kmongo/quick-start/#object-mapping-engine)
 in order to know how to select the object mapping engine.
 
+## Configure ```KotlinModule```
+
+The ```ObjectMapper``` used by KMongo uses a [jackson's KotlinModule](https://github.com/FasterXML/jackson-module-kotlin). 
+The module is created with default ```KotlinFeature```s. 
+To change configuration of the module, use ```KotlinModuleConfiguration``` object:
+
+```kotlin
+KotlinModuleConfiguration.kotlinModuleInitializer = { 
+    // Configure `KotlinModule` using its `Builder` (which is referenced as `this`):
+    enable(KotlinFeature.SingletonSupport) 
+    enable(KotlinFeature.StrictNullChecks)
+    ...
+}
+KMongoConfiguration.resetConfiguration()
+```
+
 ## Set your _id
 
 To manage Mongo ```_id```, a class must have one ```_id``` property


### PR DESCRIPTION
This pull request adds possibility to customize the `KotlinModule` used in KMongo's `ObjectMapper`.

The purpose for this feature is to be able to enable `KotlinModule`'s features that are disabled by default (eg. `KotlinFeature.SingletonSupport`).