### PR TITLE
fix : perf issue with Class.forName with Kotlinx Datetime

### DIFF
--- a/kmongo-jackson-mapping/src/main/kotlin/org/litote/kmongo/jackson/BsonModule.kt
+++ b/kmongo-jackson-mapping/src/main/kotlin/org/litote/kmongo/jackson/BsonModule.kt
@@ -77,6 +77,7 @@ import org.litote.kmongo.jackson.ExtendedJsonModule.KTXLocalTimeExtendedJsonSeri
 import org.litote.kmongo.jackson.KMongoBsonFactory.Companion.createFromLegacyFormat
 import org.litote.kmongo.jackson.KMongoBsonFactory.KMongoBsonGenerator
 import org.litote.kmongo.projection
+import org.litote.kmongo.util.KotlinxDatetimeLoader
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
@@ -639,9 +640,7 @@ internal class BsonModule(uuidRepresentation: UuidRepresentation? = null) : Simp
 
         addSerializer(KProperty::class.java, KPropertySerializer)
 
-        try {
-            Class.forName("kotlinx.datetime.Instant")
-
+        KotlinxDatetimeLoader.loadKotlinxDateTime({
             addSerializer(KTXInstant::class.java, KTXInstantBsonSerializer)
             addSerializer(KTXLocalDate::class.java, KTXLocalDateBsonSerializer)
             addSerializer(KTXLocalDateTime::class.java, KTXLocalDateTimeBsonSerializer)
@@ -651,8 +650,7 @@ internal class BsonModule(uuidRepresentation: UuidRepresentation? = null) : Simp
             addDeserializer(KTXLocalDate::class.java, KTXLocalDateBsonDeserializer)
             addDeserializer(KTXLocalDateTime::class.java, KTXLocalDateTimeBsonDeserializer)
             addDeserializer(KTXLocalTime::class.java, KTXLocalTimeBsonDeserializer)
-        }
-        catch(e:ClassNotFoundException) { }
+        }, {})
 
         if (uuidRepresentation != null) {
             addSerializer(UUID::class.java, UuidSerializer(uuidRepresentation))

--- a/kmongo-jackson-mapping/src/main/kotlin/org/litote/kmongo/jackson/ExtendedJsonModule.kt
+++ b/kmongo-jackson-mapping/src/main/kotlin/org/litote/kmongo/jackson/ExtendedJsonModule.kt
@@ -30,6 +30,7 @@ import org.bson.types.ObjectId
 import org.litote.kmongo.Id
 import org.litote.kmongo.id.IdTransformer
 import org.litote.kmongo.id.jackson.IdKeySerializer
+import org.litote.kmongo.util.KotlinxDatetimeLoader
 import org.litote.kmongo.util.PatternUtil
 import java.math.BigDecimal
 import java.time.Instant
@@ -247,15 +248,12 @@ internal class ExtendedJsonModule : SimpleModule() {
         addSerializer(LocalTime::class.java, LocalTimeExtendedJsonSerializer)
         addSerializer(OffsetTime::class.java, OffsetTimeExtendedJsonSerializer)
 
-        try {
-            Class.forName("kotlinx.datetime.Instant")
-
+        KotlinxDatetimeLoader.loadKotlinxDateTime({
             addSerializer(KTXInstant::class.java, KTXInstantExtendedJsonSerializer)
             addSerializer(KTXLocalDate::class.java, KTXLocalDateExtendedJsonSerializer)
             addSerializer(KTXLocalDateTime::class.java, KTXLocalDateTimeExtendedJsonSerializer)
             addSerializer(KTXLocalTime::class.java, KTXLocalTimeExtendedJsonSerializer)
-        }
-        catch(e:ClassNotFoundException) { }
+        }, {})
 
         addSerializer(Pattern::class.java, PatternSerializer)
         addSerializer(Regex::class.java, RegexSerializer)

--- a/kmongo-jackson-mapping/src/main/kotlin/org/litote/kmongo/jackson/JacksonCodec.kt
+++ b/kmongo-jackson-mapping/src/main/kotlin/org/litote/kmongo/jackson/JacksonCodec.kt
@@ -54,6 +54,7 @@ import org.litote.kmongo.jackson.JacksonCodec.VisitorWrapper.JsonType.string
 import org.litote.kmongo.json
 import org.litote.kmongo.util.KMongoUtil
 import org.litote.kmongo.util.KMongoUtil.generateNewIdForIdClass
+import org.litote.kmongo.util.KotlinxDatetimeLoader
 import org.litote.kmongo.util.MongoIdUtil
 import java.io.IOException
 import java.io.UncheckedIOException
@@ -99,18 +100,14 @@ internal class JacksonCodec<T : Any>(
                 LocalDateTime::class,
                 LocalTime::class,
                 OffsetTime::class
-            ) + try {
-                Class.forName("kotlinx.datetime.Instant")
-
+            ) + KotlinxDatetimeLoader.loadKotlinxDateTime({
                 setOf(
                     KTXInstant::class,
                     KTXLocalDate::class,
                     KTXLocalDateTime::class,
                     KTXLocalTime::class
                 )
-            } catch (e: ClassNotFoundException) {
-                emptySet<Any>()
-            }
+            }, { setOf<Any>() })
 
         override fun expectNullFormat(type: JavaType?): JsonNullFormatVisitor? {
             return null

--- a/kmongo-serialization-mapping/src/main/kotlin/KMongoSerializationRepository.kt
+++ b/kmongo-serialization-mapping/src/main/kotlin/KMongoSerializationRepository.kt
@@ -41,6 +41,7 @@ import org.bson.types.ObjectId
 import org.litote.kmongo.Id
 import org.litote.kmongo.id.StringId
 import org.litote.kmongo.id.WrappedObjectId
+import org.litote.kmongo.util.KotlinxDatetimeLoader
 import org.litote.kmongo.util.ObjectMappingConfiguration
 import java.math.BigDecimal
 import java.time.Instant
@@ -129,17 +130,16 @@ internal object KMongoSerializationRepository {
         Pattern::class to PatternSerializer,
         Regex::class to RegexSerializer,
         UUID::class to UUIDSerializer
-    ) +
-    try {
-        Class.forName("kotlinx.datetime.Instant")
+    ) + KotlinxDatetimeLoader.loadKotlinxDateTime({
         mapOf(
             KTXInstant::class to KTXInstantSerializer,
             KTXLocalDate::class to KTXLocalDateSerializer,
             KTXLocalDateTime::class to KTXLocalDateTimeSerializer,
             KTXLocalTime::class to KTXLocalTimeSerializer
         )
-    }
-    catch(e:ClassNotFoundException) { emptyMap() }
+    }, { mapOf() })
+
+
 
     private fun getCustomSerializer(kClass: KClass<*>): KSerializer<*>? =
         customSerializersMap[kClass] ?: serializersMap[kClass]

--- a/kmongo-shared/src/main/kotlin/org/litote/kmongo/util/KotlinxDatetimeLoader.kt
+++ b/kmongo-shared/src/main/kotlin/org/litote/kmongo/util/KotlinxDatetimeLoader.kt
@@ -1,0 +1,30 @@
+package org.litote.kmongo.util
+
+object KotlinxDatetimeLoader {
+    private var hasLoaded = false
+    private var isExistInClassLoader = false
+
+    /**
+     * Call Class.forName multiple times can cause severe perf issue
+     * if dependency kotlinx doesn't exist in project implement KMongo.
+     * So we load it only on first time and return nothing if class not exist.
+     */
+    fun <T> loadKotlinxDateTime(loadSerializersAndDeserializers: () -> T, empty: () -> T): T {
+        return try {
+            if (!hasLoaded) {
+                hasLoaded = true
+                Class.forName("kotlinx.datetime.Instant")
+                isExistInClassLoader = true
+            }
+
+            if (!isExistInClassLoader) {
+                return empty()
+            }
+
+            loadSerializersAndDeserializers()
+        } catch (e: ClassNotFoundException) {
+            isExistInClassLoader = false
+            empty()
+        }
+    }
+}


### PR DESCRIPTION
Hi,

Since kmongo 4.7.2, performance has been degraded by Class.forName with kotlinx datetime during our requests to DB.

We not using kotlinx datetime lib, so Class.forName is call each time.

By using AsyncProfiler on wall mode, we can see it :

<img width="1407" alt="perf_issue_01" src="https://user-images.githubusercontent.com/5675697/235467692-921d5917-710c-463d-8464-b58c6bac0ba5.png">

![perf_issue_02](https://user-images.githubusercontent.com/5675697/235467710-5e3a0ad6-3802-4657-85bf-5577ad073382.png)


For an hotfix for us, we added kotlinx datetime to fix issue in our side, waiting a fix on KMongo.

I have added a fix on this PR, by loading Class.forName only on first time.

Could you check it, please 🙏 ?

Sincerely,
Fabien