### PR TITLE
UUIDSerializer: Cast to parent type to deserialize a UUID within a list

### DIFF
--- a/kmongo-serialization-mapping/src/main/kotlin/Serializers.kt
+++ b/kmongo-serialization-mapping/src/main/kotlin/Serializers.kt
@@ -346,7 +346,7 @@ internal object UUIDSerializer : KSerializer<UUID> {
     override val descriptor: SerialDescriptor = buildClassSerialDescriptor("UuidSerializer")
 
     override fun deserialize(decoder: Decoder): UUID =
-        (decoder as BsonFlexibleDecoder).reader.readBinaryData().asUuid()
+        (decoder as FlexibleDecoder).reader.readBinaryData().asUuid()
 
     override fun serialize(encoder: Encoder, value: UUID) {
         (encoder as BsonEncoder).encodeUUID(value)


### PR DESCRIPTION
The `UUIDSerializer`'s deserializer will fail with a `ClassCastException` when the UUID is embedded in a list (e.g., `val foo: Collection<@Contextual UUID> = emptyList()`).  The decoder in this example is a `ListDecoder` rather than the expected `BsonFlexibleDecoder` triggering the exception.  Both, however, are `FlexibleDecoder` objects and the `reader` field is declared there.  Updated the cast to this parent type, resolving the issue.  The existing tests pass with this change.

If you need more info, please let me know.